### PR TITLE
Changed GIF url for a better performance

### DIFF
--- a/src/services/getGifs.js
+++ b/src/services/getGifs.js
@@ -15,7 +15,7 @@ const fromApiToGifs = (response) => {
 			const { id, images, title } = gif;
 
 			// Obtencion del url del objeto images, propiedad fixed_height
-			const { url } = images.fixed_height;
+			const { url } = images.fixed_height_downsampled;
 
 			// Retorno del Objeto con la Informacion necesaria
 			return { id, url, title };


### PR DESCRIPTION
It was changed the GIF url for its downsampled option.