### PR TITLE
GIF src changed, loading type and decoding has been setted

### DIFF
--- a/src/components/Gif/index.js
+++ b/src/components/Gif/index.js
@@ -1,34 +1,50 @@
 import React from "react";
 import { Link } from "wouter";
 import Fav from "components/Fav";
-import "./styles.css";
 import useNearScreen from "hooks/useNearScreen";
+import "./styles.css";
 
-const Gif = ({ gifId, url, title }) => {
-	const { isNearScreen, fromRef } = useNearScreen();
+const Gif = ({ gifId, listOfUrl, sizes, title }) => {
+	const { isNearScreen, fromRef } = useNearScreen({
+		onlyCheckViewport: true,
+	});
 
-	// if img isn't visible then loading is set to lazy
-	const loadingType = isNearScreen ? null : "lazy";
+	const { mp4, webp } = listOfUrl;
+	const { width, height } = sizes;
+
+	// if img isn't visible then loading is set to lazy and decoding async
+	const [isLazy, isDecodingAsync] = isNearScreen
+		? [null, null]
+		: ["lazy", "async"];
 
 	return (
-		<div ref={fromRef} className="Gif">
+		<figure ref={fromRef} className="Gif">
 			<div className="Gif-buttons">
 				<Fav id={gifId} />
 			</div>
 
 			<Link className="Gif-link" to={`/details/${gifId}`}>
-				<img
-					width="320"
-					height="200"
-					className="Gif-img"
-					loading={loadingType}
-					src={url}
-					alt={title}
-				/>
+				<picture>
+					<source
+						className="Gif-img"
+						srcSet={webp}
+						type="image/webp"
+					/>
 
-				<span className="Gif-title">{title}</span>
+					<img
+						width={width}
+						height={height}
+						className="Gif-img"
+						loading={isLazy}
+						decoding={isDecodingAsync}
+						src={mp4}
+						alt={title}
+					/>
+				</picture>
+
+				<figcaption className="Gif-title">{title}</figcaption>
 			</Link>
-		</div>
+		</figure>
 	);
 };
 

--- a/src/components/Gif/styles.css
+++ b/src/components/Gif/styles.css
@@ -3,6 +3,11 @@
 	min-height: 12.5rem;
 }
 
+.Gif picture {
+	width: 100%;
+	height: 100%;
+}
+
 .Gif-link {
 	display: flex;
 	flex-flow: column nowrap;

--- a/src/components/ListOfGifs/index.js
+++ b/src/components/ListOfGifs/index.js
@@ -8,8 +8,14 @@ const ListOfGifs = ({ gifs, title }) => {
 			<h2 className="ListOfGifs-title">{title}</h2>
 
 			<div className="ListOfGifs-content">
-				{gifs.map(({ id, url, title }) => (
-					<Gif key={id} gifId={id} url={url} title={title} />
+				{gifs.map(({ id, listOfUrl, sizes, title }) => (
+					<Gif
+						key={id}
+						gifId={id}
+						listOfUrl={listOfUrl}
+						sizes={sizes}
+						title={title}
+					/>
 				))}
 			</div>
 		</section>

--- a/src/components/ListOfGifs/styles.css
+++ b/src/components/ListOfGifs/styles.css
@@ -7,6 +7,6 @@
 
 .ListOfGifs-content {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
 	gap: 1rem;
 }

--- a/src/hooks/useNearScreen.js
+++ b/src/hooks/useNearScreen.js
@@ -1,7 +1,11 @@
 import { useState, useEffect, useRef } from "react";
 
 // Hook que determina cuando un componente debe renderizarse
-const useNearScreen = ({ distance = "100px", observeOnce = true } = {}) => {
+const useNearScreen = ({
+	distance = "100px",
+	observeOnce = true,
+	onlyCheckViewport = false,
+} = {}) => {
 	const [isNearScreen, setShow] = useState(false);
 
 	// Referencia al elemento a observar
@@ -17,6 +21,9 @@ const useNearScreen = ({ distance = "100px", observeOnce = true } = {}) => {
 			// Si el elemento se esta interceptando, show = true
 			if (element.isIntersecting) {
 				setShow(true);
+				observeOnce && observer.disconnect();
+			} else if (!element.isIntersecting && onlyCheckViewport) {
+				setShow(false);
 				observeOnce && observer.disconnect();
 			} else {
 				setShow(false);

--- a/src/services/getGifs.js
+++ b/src/services/getGifs.js
@@ -13,12 +13,12 @@ const fromApiToGifs = (response) => {
 		const gifs = data.map((gif) => {
 			// Obtencion del id, objeto de images y el title del Gif
 			const { id, images, title } = gif;
-
-			// Obtencion del url del objeto images, propiedad fixed_height
-			const { url } = images.downsized_medium;
+			const { mp4, webp, width, height } = images.fixed_width;
+			const listOfUrl = { mp4, webp };
+			const sizes = { width, height };
 
 			// Retorno del Objeto con la Informacion necesaria
-			return { id, url, title };
+			return { id, listOfUrl, sizes, title };
 		});
 
 		return gifs;

--- a/src/services/getSingleGif.js
+++ b/src/services/getSingleGif.js
@@ -3,9 +3,11 @@ import { API_KEY, API_URL } from "./settings";
 const fromApiToSingleGif = (response) => {
 	const { data = [] } = response;
 	const { id, images, title } = data;
-	const { url } = images.downsized_medium;
+	const { webp, mp4, width, height } = images.fixed_width;
+	const listOfUrl = { webp, mp4 };
+	const sizes = { width, height };
 
-	return { id, url, title };
+	return { id, listOfUrl, sizes, title };
 };
 
 const getSingleGif = ({ id }) => {


### PR DESCRIPTION
It was added the loading type and decoding to GIF. 

In other hand, it was modified useNearScreen hook to only check if element is in viewport to set only to certain GIFs these img attributes and disconnect once. 

It was replaced GIF src for perfomance reasons, now it displays GIFs in WebP format in case it supports it and it uses MP4 as fallback if it's not supported in user's browser.